### PR TITLE
SafeConfigParser renamed to ConfigParser in Python 3.2

### DIFF
--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -415,7 +415,7 @@ class ContentStruct(object):
     @property
     def META_TEMPLATE(self):
         KEYS_BASIC = ("StrID", "Title", "Slug")
-        KEYS_EXT = ("Cats", "Tags")
+        KEYS_EXT = ("Cats", "Tags", "Description")
         KEYS_BLOG = ("EditType", "EditFormat", "BlogAddr")
 
         pt = ['"{k:<6}: {{{t}}}'.format(k=p, t=p.lower()) for p in KEYS_BASIC]

--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -415,7 +415,7 @@ class ContentStruct(object):
     @property
     def META_TEMPLATE(self):
         KEYS_BASIC = ("StrID", "Title", "Slug")
-        KEYS_EXT = ("Cats", "Tags", "Description")
+        KEYS_EXT = ("Cats", "Tags")
         KEYS_BLOG = ("EditType", "EditFormat", "BlogAddr")
 
         pt = ['"{k:<6}: {{{t}}}'.format(k=p, t=p.lower()) for p in KEYS_BASIC]

--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -165,6 +165,7 @@ class DataObject(object):
     __xmlrpc = None
     __conf_index = 0
     __config = None
+    __env = None
 
     view = 'edit'
     vimpress_temp_dir = ''
@@ -254,6 +255,24 @@ class DataObject(object):
 
             # echomsg("done.")  ## Disabled as it pops up "press enter"
         return self.__xmlrpc
+
+    @property
+    def env(self):
+        if self.__env is None or len(self.__env) == 0:
+
+            confpsr = ConfigParser()
+            confile = os.path.expanduser("~/.vimpressenv")
+            conf_section = ["extensions"]
+
+            if os.path.exists(confile):
+                confpsr.read(confile)
+                self.__env = {}
+                for sec in confpsr.sections():
+                    if sec in conf_section:
+                        if confpsr.get(sec, "params"):
+                            self.__env[sec] = confpsr.get(sec, "params").split(',')
+
+        return self.__env
 
     @property
     def config(self):
@@ -509,7 +528,11 @@ class ContentStruct(object):
                 field = dict(key=G.CUSTOM_FIELD_KEY, value=rawtext)
                 struct["custom_fields"].append(field)
 
-            struct["description"] = self.html_text = markdown.markdown(rawtext)
+            extentions=[]
+            if "extensions" in g_data.env:
+                extensions = g_data.env["extensions"]
+            md = markdown.Markdown(extensions=extensions)
+            struct["description"] = self.html_text = md.convert(rawtext)
         else:
             struct["description"] = self.html_text = rawtext
 

--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -95,7 +95,7 @@ import os
 import mimetypes
 import webbrowser
 import tempfile
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 try:
     import markdown

--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -259,7 +259,7 @@ class DataObject(object):
     def config(self):
         if self.__config is None or len(self.__config) == 0:
 
-            confpsr = SafeConfigParser()
+            confpsr = ConfigParser()
             confile = os.path.expanduser("~/.vimpressrc")
             conf_options = ("blog_url", "username", "password")
 


### PR DESCRIPTION
> -c:174: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
